### PR TITLE
Fix missing Jinja2 template rendering

### DIFF
--- a/keyword_crawler/templates/404.html
+++ b/keyword_crawler/templates/404.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}页面未找到 - 关键词爬虫工具{% endblock %}
+
+{% block content %}
+<div class="text-center">
+    <h1 class="display-1">404</h1>
+    <p class="fs-3"><span class="text-danger">糟糕!</span> 页面未找到。</p>
+    <p class="lead">您要查找的页面不存在。</p>
+    <a href="{{ url_for('index') }}" class="btn btn-primary">返回首页</a>
+</div>
+{% endblock %}

--- a/keyword_crawler/templates/500.html
+++ b/keyword_crawler/templates/500.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}服务器错误 - 关键词爬虫工具{% endblock %}
+
+{% block content %}
+<div class="text-center">
+    <h1 class="display-1">500</h1>
+    <p class="fs-3"><span class="text-danger">糟糕!</span> 服务器内部错误。</p>
+    <p class="lead">服务器遇到了一个意外的错误。</p>
+    <a href="{{ url_for('index') }}" class="btn btn-primary">返回首页</a>
+</div>
+{% endblock %}

--- a/keyword_crawler/templates/base.html
+++ b/keyword_crawler/templates/base.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}关键词爬虫工具{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css" rel="stylesheet">
+    <style>
+        .sidebar { min-height: 100vh; }
+        .main-content { margin-left: 0; }
+        @media (min-width: 768px) {
+            .main-content { margin-left: 250px; }
+        }
+    </style>
+</head>
+<body>
+    <div class="container-fluid">
+        <div class="row">
+            <!-- 侧边栏 -->
+            <nav class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse">
+                <div class="position-sticky pt-3">
+                    <h5 class="px-3 mb-3">关键词爬虫</h5>
+                    <ul class="nav flex-column">
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('index') }}">
+                                <i class="bi bi-house"></i> 首页
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('keywords') }}">
+                                <i class="bi bi-tags"></i> 关键词管理
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('tasks') }}">
+                                <i class="bi bi-clock"></i> 任务管理
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('statistics') }}">
+                                <i class="bi bi-graph-up"></i> 数据统计
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('visualizations') }}">
+                                <i class="bi bi-bar-chart"></i> 数据可视化
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('config') }}">
+                                <i class="bi bi-gear"></i> 配置
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </nav>
+
+            <!-- 主内容区 -->
+            <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4 main-content">
+                <div class="pt-3">
+                    {% block content %}{% endblock %}
+                </div>
+            </main>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/keyword_crawler/templates/config.html
+++ b/keyword_crawler/templates/config.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block title %}配置 - 关键词爬虫工具{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">系统配置</h1>
+</div>
+
+<div class="row">
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">
+                <h5>搜索引擎</h5>
+            </div>
+            <div class="card-body">
+                <ul class="list-group list-group-flush">
+                    {% if config.search_engines %}
+                        {% for engine in config.search_engines %}
+                        <li class="list-group-item">{{ engine }}</li>
+                        {% endfor %}
+                    {% else %}
+                        <li class="list-group-item">暂无配置</li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">
+                <h5>默认关键词</h5>
+            </div>
+            <div class="card-body">
+                <ul class="list-group list-group-flush">
+                    {% if config.default_keywords %}
+                        {% for keyword in config.default_keywords %}
+                        <li class="list-group-item">{{ keyword }}</li>
+                        {% endfor %}
+                    {% else %}
+                        <li class="list-group-item">暂无配置</li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-header">
+                <h5>调度器配置</h5>
+            </div>
+            <div class="card-body">
+                {% if config.scheduler_config %}
+                    {% for key, value in config.scheduler_config.items() %}
+                    <p><strong>{{ key }}:</strong> {{ value }}</p>
+                    {% endfor %}
+                {% else %}
+                    <p class="text-muted">暂无配置</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/keyword_crawler/templates/index.html
+++ b/keyword_crawler/templates/index.html
@@ -1,0 +1,119 @@
+{% extends "base.html" %}
+
+{% block title %}首页 - 关键词爬虫工具{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">系统概览</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <button type="button" class="btn btn-primary" onclick="searchNow()">
+            <i class="bi bi-search"></i> 立即搜索
+        </button>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-3">
+        <div class="card text-white bg-primary mb-3">
+            <div class="card-body">
+                <h5 class="card-title">总搜索结果</h5>
+                <h2>{{ summary.total_search_results or 0 }}</h2>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-white bg-success mb-3">
+            <div class="card-body">
+                <h5 class="card-title">总任务数</h5>
+                <h2>{{ summary.total_tasks or 0 }}</h2>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-white bg-info mb-3">
+            <div class="card-body">
+                <h5 class="card-title">成功率</h5>
+                <h2>{{ summary.success_rate or 0 }}%</h2>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-3">
+        <div class="card text-white bg-warning mb-3">
+            <div class="card-body">
+                <h5 class="card-title">活跃关键词</h5>
+                <h2>{{ summary.active_keywords or 0 }}</h2>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5>热门关键词</h5>
+            </div>
+            <div class="card-body">
+                <ul class="list-group list-group-flush">
+                    {% if summary.top_keywords %}
+                        {% for keyword, count in summary.top_keywords.items() %}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            {{ keyword }}
+                            <span class="badge bg-primary rounded-pill">{{ count }}</span>
+                        </li>
+                        {% endfor %}
+                    {% else %}
+                        <li class="list-group-item">暂无数据</li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5>搜索引擎性能</h5>
+            </div>
+            <div class="card-body">
+                {% if summary.engine_performance %}
+                    {% for engine, stats in summary.engine_performance.items() %}
+                    <div class="mb-3">
+                        <div class="d-flex justify-content-between">
+                            <span>{{ engine }}</span>
+                            <span>{{ stats.success_rate }}%</span>
+                        </div>
+                        <div class="progress">
+                            <div class="progress-bar" role="progressbar" style="width: {{ stats.success_rate }}%"></div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                {% else %}
+                    <p class="text-muted">暂无数据</p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function searchNow() {
+    if (confirm('确定要立即执行搜索吗？')) {
+        axios.post('/api/search_now', {
+            keywords: [],
+            pages: 1
+        }).then(response => {
+            if (response.data.success) {
+                alert(response.data.message);
+                location.reload();
+            } else {
+                alert('搜索失败: ' + response.data.message);
+            }
+        }).catch(error => {
+            alert('请求失败: ' + error.message);
+        });
+    }
+}
+</script>
+{% endblock %}

--- a/keyword_crawler/templates/keywords.html
+++ b/keyword_crawler/templates/keywords.html
@@ -1,0 +1,105 @@
+{% extends "base.html" %}
+
+{% block title %}关键词管理 - 关键词爬虫工具{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">关键词管理</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#addKeywordModal">
+            <i class="bi bi-plus"></i> 添加关键词
+        </button>
+    </div>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>关键词</th>
+                <th>创建时间</th>
+                <th>状态</th>
+                <th>操作</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for keyword in keywords %}
+            <tr>
+                <td>{{ keyword.keyword if keyword.keyword else keyword }}</td>
+                <td>{{ keyword.created_at if keyword.created_at else '未知' }}</td>
+                <td>
+                    {% if keyword.is_active is defined %}
+                        {% if keyword.is_active %}
+                            <span class="badge bg-success">活跃</span>
+                        {% else %}
+                            <span class="badge bg-secondary">已停用</span>
+                        {% endif %}
+                    {% else %}
+                        <span class="badge bg-success">活跃</span>
+                    {% endif %}
+                </td>
+                <td>
+                    <button class="btn btn-sm btn-danger" onclick="deleteKeyword('{{ keyword.id if keyword.id else keyword }}')">删除</button>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+<!-- 添加关键词模态框 -->
+<div class="modal fade" id="addKeywordModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">添加关键词</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <form id="addKeywordForm">
+                    <div class="mb-3">
+                        <label for="keyword" class="form-label">关键词</label>
+                        <input type="text" class="form-control" id="keyword" name="keyword" required>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">取消</button>
+                <button type="button" class="btn btn-primary" onclick="addKeyword()">添加</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function addKeyword() {
+    const keyword = document.getElementById('keyword').value.trim();
+    if (!keyword) {
+        alert('请输入关键词');
+        return;
+    }
+    
+    axios.post('/api/keywords', { keyword: keyword })
+    .then(response => {
+        if (response.data.success) {
+            alert(response.data.message);
+            location.reload();
+        } else {
+            alert('添加失败: ' + response.data.message);
+        }
+    })
+    .catch(error => {
+        alert('请求失败: ' + error.message);
+    });
+}
+
+function deleteKeyword(keywordId) {
+    if (confirm('确定要删除这个关键词吗？')) {
+        // 这里需要添加删除API调用
+        alert('删除功能尚未实现');
+    }
+}
+</script>
+{% endblock %}

--- a/keyword_crawler/templates/statistics.html
+++ b/keyword_crawler/templates/statistics.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block title %}数据统计 - 关键词爬虫工具{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">数据统计</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <select class="form-select" onchange="changeDays(this.value)">
+            <option value="7" {% if days == 7 %}selected{% endif %}>最近7天</option>
+            <option value="30" {% if days == 30 %}selected{% endif %}>最近30天</option>
+            <option value="90" {% if days == 90 %}selected{% endif %}>最近90天</option>
+        </select>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5>任务统计</h5>
+            </div>
+            <div class="card-body">
+                <p>总任务数: {{ task_stats.total or 0 }}</p>
+                <p>成功任务: {{ task_stats.success or 0 }}</p>
+                <p>失败任务: {{ task_stats.failed or 0 }}</p>
+                <p>成功率: {{ task_stats.success_rate or 0 }}%</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5>搜索结果统计</h5>
+            </div>
+            <div class="card-body">
+                <p>总搜索结果: {{ results_stats.total or 0 }}</p>
+                <p>平均每天: {{ results_stats.daily_average or 0 }}</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function changeDays(days) {
+    window.location.href = '/statistics?days=' + days;
+}
+</script>
+{% endblock %}

--- a/keyword_crawler/templates/tasks.html
+++ b/keyword_crawler/templates/tasks.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+
+{% block title %}任务管理 - 关键词爬虫工具{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">任务管理</h1>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>任务ID</th>
+                <th>状态</th>
+                <th>下次执行</th>
+                <th>上次执行</th>
+                <th>操作</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for job in jobs %}
+            <tr>
+                <td>{{ job.id }}</td>
+                <td>
+                    {% if job.paused %}
+                        <span class="badge bg-warning">已暂停</span>
+                    {% else %}
+                        <span class="badge bg-success">运行中</span>
+                    {% endif %}
+                </td>
+                <td>{{ job.next_run_time or '未安排' }}</td>
+                <td>{{ job.last_run_time or '从未执行' }}</td>
+                <td>
+                    <div class="btn-group" role="group">
+                        <button class="btn btn-sm btn-primary" onclick="runTask('{{ job.id }}')">立即执行</button>
+                        {% if job.paused %}
+                            <button class="btn btn-sm btn-success" onclick="resumeTask('{{ job.id }}')">恢复</button>
+                        {% else %}
+                            <button class="btn btn-sm btn-warning" onclick="pauseTask('{{ job.id }}')">暂停</button>
+                        {% endif %}
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function runTask(taskId) {
+    if (confirm('确定要立即执行任务 ' + taskId + ' 吗？')) {
+        axios.post('/api/tasks/' + taskId + '/run')
+        .then(response => {
+            if (response.data.success) {
+                alert(response.data.message);
+                location.reload();
+            } else {
+                alert('操作失败: ' + response.data.message);
+            }
+        })
+        .catch(error => {
+            alert('请求失败: ' + error.message);
+        });
+    }
+}
+
+function pauseTask(taskId) {
+    if (confirm('确定要暂停任务 ' + taskId + ' 吗？')) {
+        axios.post('/api/tasks/' + taskId + '/pause')
+        .then(response => {
+            if (response.data.success) {
+                alert(response.data.message);
+                location.reload();
+            } else {
+                alert('操作失败: ' + response.data.message);
+            }
+        })
+        .catch(error => {
+            alert('请求失败: ' + error.message);
+        });
+    }
+}
+
+function resumeTask(taskId) {
+    if (confirm('确定要恢复任务 ' + taskId + ' 吗？')) {
+        axios.post('/api/tasks/' + taskId + '/resume')
+        .then(response => {
+            if (response.data.success) {
+                alert(response.data.message);
+                location.reload();
+            } else {
+                alert('操作失败: ' + response.data.message);
+            }
+        })
+        .catch(error => {
+            alert('请求失败: ' + error.message);
+        });
+    }
+}
+</script>
+{% endblock %}

--- a/keyword_crawler/templates/visualizations.html
+++ b/keyword_crawler/templates/visualizations.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}数据可视化 - 关键词爬虫工具{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
+    <h1 class="h2">数据可视化</h1>
+    <div class="btn-toolbar mb-2 mb-md-0">
+        <button type="button" class="btn btn-primary" onclick="generateCharts()">
+            <i class="bi bi-graph-up"></i> 生成图表
+        </button>
+    </div>
+</div>
+
+<div id="chartsContainer">
+    <p class="text-muted">点击"生成图表"按钮来创建可视化图表</p>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+function generateCharts() {
+    axios.get('/api/generate_charts?days={{ days or 7 }}')
+    .then(response => {
+        if (response.data.success) {
+            alert(response.data.message);
+            // 这里可以添加显示图表的逻辑
+        } else {
+            alert('生成失败: ' + response.data.message);
+        }
+    })
+    .catch(error => {
+        alert('请求失败: ' + error.message);
+    });
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
Add all missing Jinja2 templates to resolve `TemplateNotFound` errors for various application routes.

The `create_templates()` method was only generating `base.html` and `index.html`, leading to `TemplateNotFound` exceptions when accessing other routes like `/tasks`. This PR ensures all necessary templates are created and available.